### PR TITLE
Update error messages for mark/unmark Task commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -22,7 +22,8 @@ public class MarkTaskCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Task marked as done:\n%1$s\nIn Wedding: %2$s";
     public static final String MESSAGE_WEDDING_NOT_FOUND = "Wedding with ID %1$s not found.";
     public static final String MESSAGE_INVALID_TASK_INDEX = "Invalid task index for wedding %1$s.";
-    public static final String MESSAGE_TASK_ALREADY_DONE = "This task is already marked as done:\n%1$s\nIn Wedding: %2$s";
+    public static final String MESSAGE_TASK_ALREADY_DONE =
+            "This task is already marked as done:\n%1$s\nIn Wedding: %2$s";
 
     private final WeddingId weddingId;
     private final int taskIndex;

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -22,6 +22,7 @@ public class MarkTaskCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Task marked as done:\n%1$s\nIn Wedding: %2$s";
     public static final String MESSAGE_WEDDING_NOT_FOUND = "Wedding with ID %1$s not found.";
     public static final String MESSAGE_INVALID_TASK_INDEX = "Invalid task index for wedding %1$s.";
+    public static final String MESSAGE_TASK_ALREADY_DONE = "This task is already marked as done:\n%1$s\nIn Wedding: %2$s";
 
     private final WeddingId weddingId;
     private final int taskIndex;
@@ -50,6 +51,11 @@ public class MarkTaskCommand extends Command {
 
         try {
             WeddingTask taskToMark = wedding.getTasks().get(taskIndex - 1); // zero-based
+            // Check if task is already done
+            if (taskToMark.isDone()) {
+                throw new CommandException(String.format(MESSAGE_TASK_ALREADY_DONE,
+                        taskToMark, wedding.getWeddingName().fullWeddingName));
+            }
             taskToMark.markAsDone();
 
             String resultMsg = String.format(MESSAGE_SUCCESS,

--- a/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
@@ -22,7 +22,8 @@ public class UnmarkTaskCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Task marked as not done:\n%1$s\nIn Wedding: %2$s";
     public static final String MESSAGE_WEDDING_NOT_FOUND = "Wedding with ID %1$s not found.";
     public static final String MESSAGE_INVALID_TASK_INDEX = "Invalid task index for wedding %1$s.";
-    public static final String MESSAGE_TASK_ALREADY_NOT_DONE = "This task is already marked as not done:\n%1$s\nIn Wedding: %2$s";
+    public static final String MESSAGE_TASK_ALREADY_NOT_DONE =
+            "This task is already marked as not done:\n%1$s\nIn Wedding: %2$s";
 
     private final WeddingId weddingId;
     private final int taskIndex;

--- a/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
@@ -22,6 +22,7 @@ public class UnmarkTaskCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Task marked as not done:\n%1$s\nIn Wedding: %2$s";
     public static final String MESSAGE_WEDDING_NOT_FOUND = "Wedding with ID %1$s not found.";
     public static final String MESSAGE_INVALID_TASK_INDEX = "Invalid task index for wedding %1$s.";
+    public static final String MESSAGE_TASK_ALREADY_NOT_DONE = "This task is already marked as not done:\n%1$s\nIn Wedding: %2$s";
 
     private final WeddingId weddingId;
     private final int taskIndex;
@@ -49,6 +50,12 @@ public class UnmarkTaskCommand extends Command {
 
         try {
             WeddingTask taskToUnmark = wedding.getTasks().get(taskIndex - 1);
+            // Check if task is already not done
+            if (!taskToUnmark.isDone()) {
+                throw new CommandException(String.format(MESSAGE_TASK_ALREADY_NOT_DONE,
+                        taskToUnmark, wedding.getWeddingName().fullWeddingName));
+            }
+
             taskToUnmark.unmark();
 
             String resultMsg = String.format(MESSAGE_SUCCESS,


### PR DESCRIPTION
consider the case where the user may try to mark a task that is already marked? and likewise for the unmark command.

fixes #116 