### PR TITLE
Fix filter bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWeddingCommand.java
@@ -56,10 +56,6 @@ public class DeleteWeddingCommand extends Command {
         Tag tagToDelete = new Tag(weddingId);
         model.removeTagFromAllContacts(tagToDelete);
 
-        // Update the filtered lists to be empty.
-        model.updateFilteredWeddingList(w -> false);
-        model.updateFilteredPersonList(p -> false);
-
         return new CommandResult(String.format(MESSAGE_SUCCESS, weddingToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -64,7 +64,7 @@ public class UntagCommand extends Command {
         model.untagPerson(personToUntag, tag);
 
         // Reapply the filter so that only persons with the specified wedding id remain.
-        model.updateFilteredPersonList(new TagMatchesPredicate(weddingId));
+        // model.updateFilteredPersonList(new TagMatchesPredicate(weddingId));
 
         return new CommandResult(String.format(MESSAGE_UNTAG_PERSON_SUCCESS,
                 personToUntag.getName().fullName, weddingId));


### PR DESCRIPTION
- fix bug where untagging removes entire person list
- fix bug where deleting wedding removes entire person list

In UG, under filter section, need to add reminder users to use `list` command first after `filter WEDDING_ID` before executing any other commands such `addTask` or `tag`.

fixes #262 #268 